### PR TITLE
add custom variable taoline-show-buffer-name

### DIFF
--- a/taoline.el
+++ b/taoline.el
@@ -98,6 +98,9 @@
 (defcustom taoline-show-directory t
   "Set this if you want to show the direcory path as well as the file-name in the modeline proxy."
   :group 'taoline)
+(defcustom taoline-show-buffer-name t
+  "Set this if you want to show the current 'buffer-name' in the modeline proxy."
+  :group 'taoline)
 
 (defun taoline-previous-buffer-name ()
   "Get name of previous buffer."
@@ -140,11 +143,16 @@ sent to `add-text-properties'.")
                 (file-name-directory (buffer-file-name)))
              ""))
     (face taoline-dir-face))
-   ("%s" ((if (buffer-file-name) (file-name-nondirectory (buffer-file-name))
-            (buffer-name)))
+   ("%s" ((if taoline-show-buffer-name
+              (if (buffer-file-name)
+                  (file-name-nondirectory (buffer-file-name))
+                (buffer-name))
+            ""))
     (face taoline-bufname-face))
-   ("%s" ((if (and (buffer-file-name) (buffer-modified-p)) "*"
-            "" ))
+   ("%s" ((if taoline-show-buffer-name
+              (if (and (buffer-file-name) (buffer-modified-p)) "*"
+                "" )
+            ""))
     (face taoline-asterisk-face))
    ("%s" ((if taoline-show-git-branch (concat " : " (taoline--git-branch-string))
             ""))


### PR DESCRIPTION
I make little changes so that users can decide whether to show buffer name or not. Since someone may use the frame title to show the current buffer name, then they don't need to show buffer name at echo area.

Screenshoot : 

![Screenshot from 2019-03-16 15-11-23](https://user-images.githubusercontent.com/32809182/54472085-c9d52d80-47fd-11e9-9749-833b39790463.png)

 Thanks for making this clean and elegant package.